### PR TITLE
Fix C exception handling & null-termination error.

### DIFF
--- a/ext/nokogiri_ext_xmlsec/nokogiri_helpers_set_attribute_id.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_helpers_set_attribute_id.c
@@ -1,43 +1,63 @@
 #include "xmlsecrb.h"
 
 VALUE set_id_attribute(VALUE self, VALUE rb_attr_name) {
-  xmlNodePtr node;
-  xmlAttrPtr attr;
-  xmlAttrPtr tmp;
-  xmlChar *name;
-  const xmlChar *idName;
+  VALUE rb_exception_result = Qnil;
+  const char* exception_message = NULL;
+
+  xmlNodePtr node = NULL;
+  xmlAttrPtr attr = NULL;
+  xmlAttrPtr tmp = NULL;
+  xmlChar *name = NULL;
+  char *idName = NULL;
+  char exception_message_buffer[1024] = {'\0'};
   
   Data_Get_Struct(self, xmlNode, node);
   Check_Type(rb_attr_name, T_STRING);
-  idName = (const xmlChar *)RSTRING_PTR(rb_attr_name);
+  idName = strndup(RSTRING_PTR(rb_attr_name),
+                   RSTRING_LEN(rb_attr_name) + 1);
 
   // find pointer to id attribute
-  attr = xmlHasProp(node, idName);
+  attr = xmlHasProp(node, (const xmlChar* )idName);
   if((attr == NULL) || (attr->children == NULL)) {
-    rb_raise(rb_eRuntimeError, "Can't find attribute to add register as id");
-    return Qfalse;
+    rb_exception_result = rb_eRuntimeError;
+    exception_message = "Can't find attribute to add register as id";
+    goto done;
   }
   
   // get the attribute (id) value
   name = xmlNodeListGetString(node->doc, attr->children, 1);
   if(name == NULL) {
-    rb_raise(rb_eRuntimeError, "Attribute %s has no value", idName);
-    return Qfalse;
+    rb_exception_result = rb_eRuntimeError;
+    snprintf(exception_message_buffer, sizeof(exception_message_buffer),
+             "Attribute %s has no value", idName);
+    exception_message = &exception_message_buffer[0];
+    goto done;
   }
   
   // check that we don't have that id already registered
   tmp = xmlGetID(node->doc, name);
   if(tmp != NULL) {
-    // rb_raise(rb_eRuntimeError, "Attribute %s is already an ID", idName);
-    xmlFree(name);
-    return Qfalse;
+    rb_exception_result = rb_eRuntimeError;
+    snprintf(exception_message_buffer, sizeof(exception_message_buffer),
+             "Attribute %s is already an ID", idName);
+    exception_message = &exception_message_buffer[0];
+    goto done;
   }
   
   // finally register id
   xmlAddID(NULL, node->doc, name, attr);
 
+done:
   // and do not forget to cleanup
-  xmlFree(name);
+  if (name) {
+    xmlFree(name);
+  }
+
+  free(idName);
+
+  if(rb_exception_result != Qnil) {
+    rb_raise(rb_exception_result, "%s", exception_message);
+  }
 
   return Qtrue;
 }

--- a/ext/nokogiri_ext_xmlsec/nokogiri_init.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_init.c
@@ -1,12 +1,12 @@
 #include "xmlsecrb.h"
 
-VALUE rb_cNokogiri_XML_Document = T_NIL;
-VALUE rb_cNokogiri_XML_Node = T_NIL;
-VALUE rb_eSigningError = T_NIL;
-VALUE rb_eVerificationError = T_NIL;
-VALUE rb_eKeystoreError = T_NIL;
-VALUE rb_eEncryptionError = T_NIL;
-VALUE rb_eDecryptionError = T_NIL;
+VALUE rb_cNokogiri_XML_Document = Qnil;
+VALUE rb_cNokogiri_XML_Node = Qnil;
+VALUE rb_eSigningError = Qnil;
+VALUE rb_eVerificationError = Qnil;
+VALUE rb_eKeystoreError = Qnil;
+VALUE rb_eEncryptionError = Qnil;
+VALUE rb_eDecryptionError = Qnil;
 
 void Init_Nokogiri_ext() {
   VALUE XMLSec = rb_define_module("XMLSec");

--- a/ext/nokogiri_ext_xmlsec/nokogiri_sign_certificate.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_sign_certificate.c
@@ -1,28 +1,38 @@
 #include "xmlsecrb.h"
 
 VALUE sign_with_certificate(VALUE self, VALUE rb_key_name, VALUE rb_rsa_key, VALUE rb_cert) {
-  xmlDocPtr doc;
+  VALUE rb_exception_result = Qnil;
+  const char* exception_message = NULL;
+
+  xmlDocPtr doc = NULL;
   xmlNodePtr signNode = NULL;
   xmlNodePtr refNode = NULL;
   xmlNodePtr keyInfoNode = NULL;
   xmlSecDSigCtxPtr dsigCtx = NULL;
-  char *keyName;
-  char *certificate;
-  char *rsaKey;
-  unsigned int rsaKeyLength, certificateLength;
+  char *keyName = NULL;
+  char *certificate = NULL;
+  char *rsaKey = NULL;
+  unsigned int rsaKeyLength = 0;
+  unsigned int certificateLength = 0;
 
   Data_Get_Struct(self, xmlDoc, doc);
+
+  Check_Type(rb_rsa_key, T_STRING);
+  Check_Type(rb_key_name, T_STRING);
+  Check_Type(rb_cert, T_STRING);
+
   rsaKey = RSTRING_PTR(rb_rsa_key);
   rsaKeyLength = RSTRING_LEN(rb_rsa_key);
-  keyName = RSTRING_PTR(rb_key_name);
+  keyName = strndup(RSTRING_PTR(rb_key_name), RSTRING_LEN(rb_key_name) + 1);
   certificate = RSTRING_PTR(rb_cert);
   certificateLength = RSTRING_LEN(rb_cert);
 
   // create signature template for RSA-SHA1 enveloped signature
   signNode = xmlSecTmplSignatureCreate(doc, xmlSecTransformExclC14NId,
-                                         xmlSecTransformRsaSha1Id, NULL);
+                                       xmlSecTransformRsaSha1Id, NULL);
   if (signNode == NULL) {
-    rb_raise(rb_eSigningError, "failed to create signature template");
+    rb_exception_result = rb_eSigningError;
+    exception_message = "failed to create signature template";
     goto done;
   }
 
@@ -31,34 +41,47 @@ VALUE sign_with_certificate(VALUE self, VALUE rb_key_name, VALUE rb_rsa_key, VAL
 
   // add reference
   refNode = xmlSecTmplSignatureAddReference(signNode, xmlSecTransformSha1Id,
-                                        NULL, NULL, NULL);
+                                            NULL,
+                                            NULL,
+                                            NULL);
   if(refNode == NULL) {
-    rb_raise(rb_eSigningError, "failed to add reference to signature template");
+    rb_exception_result = rb_eSigningError;
+    exception_message = "failed to add reference to signature template";
     goto done;
   }
 
   // add enveloped transform
   if(xmlSecTmplReferenceAddTransform(refNode, xmlSecTransformEnvelopedId) == NULL) {
-    rb_raise(rb_eSigningError, "failed to add enveloped transform to reference");
+    rb_exception_result = rb_eSigningError;
+    exception_message = "failed to add enveloped transform to reference";
+    goto done;
+  }
+
+  if(xmlSecTmplReferenceAddTransform(refNode, xmlSecTransformExclC14NId) == NULL) {
+    rb_exception_result = rb_eSigningError;
+    exception_message = "failed to add canonicalization transform to reference";
     goto done;
   }
 
   // add <dsig:KeyInfo/> and <dsig:X509Data/>
   keyInfoNode = xmlSecTmplSignatureEnsureKeyInfo(signNode, NULL);
   if(keyInfoNode == NULL) {
-    rb_raise(rb_eSigningError, "failed to add key info");
+    rb_exception_result = rb_eSigningError;
+    exception_message = "failed to add key info";
     goto done;
   }
   
   if(xmlSecTmplKeyInfoAddX509Data(keyInfoNode) == NULL) {
-    rb_raise(rb_eSigningError, "failed to add X509Data node");
+    rb_exception_result = rb_eSigningError;
+    exception_message = "failed to add X509Data node";
     goto done;
   }
 
   // create signature context, we don't need keys manager in this example
   dsigCtx = xmlSecDSigCtxCreate(NULL);
   if(dsigCtx == NULL) {
-    rb_raise(rb_eSigningError, "failed to create signature context");
+    rb_exception_result = rb_eSigningError;
+    exception_message = "failed to create signature context";
     goto done;
   }
 
@@ -70,7 +93,8 @@ VALUE sign_with_certificate(VALUE self, VALUE rb_key_name, VALUE rb_rsa_key, VAL
                                                   NULL,
                                                   NULL);
   if(dsigCtx->signKey == NULL) {
-    rb_raise(rb_eSigningError, "failed to load private key");
+    rb_exception_result = rb_eSigningError;
+    exception_message = "failed to load private key";
     goto done;
   }
   
@@ -79,19 +103,22 @@ VALUE sign_with_certificate(VALUE self, VALUE rb_key_name, VALUE rb_rsa_key, VAL
                                       (xmlSecByte *)certificate,
                                       certificateLength,
                                       xmlSecKeyDataFormatPem) < 0) {
-    rb_raise(rb_eSigningError, "failed to load certificate");
+    rb_exception_result = rb_eSigningError;
+    exception_message = "failed to load certificate";
     goto done;
   }
 
   // set key name
   if(xmlSecKeySetName(dsigCtx->signKey, (xmlSecByte *)keyName) < 0) {
-    rb_raise(rb_eSigningError, "failed to set key name");
+    rb_exception_result = rb_eSigningError;
+    exception_message = "failed to set key name";
     goto done;
   }
 
   // sign the template
   if(xmlSecDSigCtxSign(dsigCtx, signNode) < 0) {
-    rb_raise(rb_eSigningError, "signature failed");
+    rb_exception_result = rb_eSigningError;
+    exception_message = "signature failed";
     goto done;
   }
 
@@ -100,5 +127,11 @@ done:
     xmlSecDSigCtxDestroy(dsigCtx);
   }
 
-  return T_NIL;
+  free(keyName);
+
+  if(rb_exception_result != Qnil) {
+    rb_raise(rb_exception_result, "%s", exception_message);
+  }
+
+  return Qnil;
 }

--- a/ext/nokogiri_ext_xmlsec/util.c
+++ b/ext/nokogiri_ext_xmlsec/util.c
@@ -1,0 +1,72 @@
+#include "util.h"
+
+xmlSecKeysMngrPtr getKeyManager(char* keyStr, unsigned int keyLength,
+                                char *keyName,
+                                VALUE* rb_exception_result_out,
+                                const char** exception_message_out) {
+  VALUE rb_exception_result = Qnil;
+  const char* exception_message = NULL;
+  xmlSecKeysMngrPtr mngr = NULL;
+  xmlSecKeyPtr key = NULL;
+  
+  /* create and initialize keys manager, we use a simple list based
+   * keys manager, implement your own xmlSecKeysStore klass if you need
+   * something more sophisticated 
+   */
+  mngr = xmlSecKeysMngrCreate();
+  if(mngr == NULL) {
+    rb_exception_result = rb_eDecryptionError;
+    exception_message = "failed to create keys manager.";
+    goto done;
+  }
+  if(xmlSecCryptoAppDefaultKeysMngrInit(mngr) < 0) {
+    rb_exception_result = rb_eDecryptionError;
+    exception_message = "failed to initialize keys manager.";
+    goto done;
+  }    
+  
+  /* load private RSA key */
+  // key = xmlSecCryptoAppKeyLoad(key_file, xmlSecKeyDataFormatPem, NULL, NULL, NULL);
+  key = xmlSecCryptoAppKeyLoadMemory((xmlSecByte *)keyStr,
+                                     keyLength,
+                                     xmlSecKeyDataFormatPem,
+                                     NULL, // password
+                                     NULL, NULL);
+  if(key == NULL) {
+    rb_exception_result = rb_eDecryptionError;
+    exception_message = "failed to load rsa key";
+    goto done;
+  }
+
+  /* set key name to the file name, this is just an example! */
+  if(xmlSecKeySetName(key, BAD_CAST keyName) < 0) {
+    rb_exception_result = rb_eDecryptionError;
+    exception_message = "failed to set key name";
+    goto done;
+  }
+
+  /* add key to keys manager, from now on keys manager is responsible 
+   * for destroying key 
+   */
+  if(xmlSecCryptoAppDefaultKeysMngrAdoptKey(mngr, key) < 0) {
+    rb_exception_result = rb_eDecryptionError;
+    exception_message = "failed to add key to keys manager";
+    goto done;
+  }
+
+done:
+  if(rb_exception_result != Qnil) {
+    if (key) {
+      xmlSecKeyDestroy(key);
+    }
+
+    if (mngr) {
+      xmlSecKeysMngrDestroy(mngr);
+      mngr = NULL;
+    }
+  }
+
+  *rb_exception_result_out = rb_exception_result;
+  *exception_message_out = exception_message;
+  return mngr;
+}

--- a/ext/nokogiri_ext_xmlsec/util.h
+++ b/ext/nokogiri_ext_xmlsec/util.h
@@ -1,0 +1,11 @@
+#ifndef NOKOGIRI_EXT_XMLSEC_UTIL_H
+#define NOKOGIRI_EXT_XMLSEC_UTIL_H
+
+#include "xmlsecrb.h"
+
+xmlSecKeysMngrPtr getKeyManager(char* keyStr, unsigned int keyLength,
+                                char *keyName,
+                                VALUE* rb_exception_result_out,
+                                const char** exception_message_out);
+
+#endif  // NOKOGIRI_EXT_XMLSEC_UTIL_H

--- a/ext/nokogiri_ext_xmlsec/xmlsecrb.h
+++ b/ext/nokogiri_ext_xmlsec/xmlsecrb.h
@@ -1,5 +1,5 @@
-#ifndef XMLSECRB_H
-#define XMLSECRB_H
+#ifndef NOKOGIRI_EXT_XMLSEC_XMLSECRB_H
+#define NOKOGIRI_EXT_XMLSEC_XMLSECRB_H
 
 #include <ruby.h>
 
@@ -36,4 +36,4 @@ extern VALUE rb_eKeystoreError;
 extern VALUE rb_eEncryptionError;
 extern VALUE rb_eDecryptionError;
 
-#endif // XMLSECRB_H
+#endif // NOKOGIRI_EXT_XMLSEC_XMLSECRB_H


### PR DESCRIPTION
rb_raise() uses longjmp() to exit the function scope. The goto done
method of cleanup does not executed with the longjmp. Fix by delaying
all raises until the end of the function to preserve a uniform error
handling pattern.

Also, ruby strings are not guaranteed to be null terminated. Strings
that are passed to APIs without explicit length arguments are copied and
cleaned up.

Lastly, enforce type checks everywhere before grabbing an RSTRING_PTR.
